### PR TITLE
現行Color Gameへダークモードと安全対策を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test color game
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Check JavaScript syntax
+        run: |
+          node --check script.js
+          node --check theme-safety.js
+          node --check tests/static-check.cjs
+
+      - name: Run static regression checks
+        run: node tests/static-check.cjs

--- a/index.html
+++ b/index.html
@@ -11,15 +11,16 @@
 <div class="container" id="game-container">
   
   <div class="header-row">
+    <button id="theme-toggle-btn" class="header-icon-btn theme-toggle-btn" aria-label="ダークモードへ切り替える" title="ライト／ダークモード">🌙</button>
     <h1>色覚検定ゲーム</h1>
-    <button id="sound-toggle-btn" aria-label="効果音の切り替え" title="効果音 ON/OFF">🔊</button>
+    <button id="sound-toggle-btn" class="header-icon-btn sound-toggle-btn" aria-label="効果音の切り替え" title="効果音 ON/OFF">🔊</button>
   </div>
 
   <!-- 強調体験モードON/OFF -->
   <div id="highlight-switcher">
     <span>強調体験モード</span>
     <button id="highlight-btn" aria-pressed="false" title="色弱の人が「区別しにくい」世界をより体感できます">OFF</button>
-    <span style="font-size:0.9em;color:#666;">
+    <span class="highlight-description">
       <span id="highlight-desc">(ONにすると1～3問目の色が“かなり近い色”に)</span>
     </span>
   </div>
@@ -44,6 +45,7 @@
   
   <!-- aria-live="assertive" でスクリーンリーダーに即座に通知 -->
   <p id="result-message" aria-live="assertive"></p>
+  <p id="app-status" class="app-status hidden" aria-live="polite"></p>
   
   <div class="controls">
     <button id="start-btn">ゲーム開始</button>
@@ -54,5 +56,6 @@
 
 </div>
 <script src="script.js"></script>
+<script src="theme-safety.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -6,35 +6,66 @@
   --title-font-size: 2.2rem;
   --info-font-size: 1rem;
   --button-font-size: 1rem;
+  --page-bg: #f0f2f5;
+  --surface-bg: #ffffff;
+  --text-color: #333333;
+  --muted-text: #5f6368;
+  --primary-color: #1a73e8;
+  --primary-soft-bg: #e8f0fe;
+  --secondary-bg: #f4f7fa;
+  --board-bg: #eeeeee;
+  --neutral-button-bg: #eeeeee;
+  --neutral-button-text: #222222;
+  --border-color: #666666;
+  --advice-bg: #fcfcfc;
+  --surface-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  color-scheme: light;
 }
+
+html[data-theme="dark"] {
+  --page-bg: #111827;
+  --surface-bg: #1f2937;
+  --text-color: #f3f4f6;
+  --muted-text: #cbd5e1;
+  --primary-color: #79b8ff;
+  --primary-soft-bg: #273449;
+  --secondary-bg: #263244;
+  --board-bg: #111827;
+  --neutral-button-bg: #334155;
+  --neutral-button-text: #f8fafc;
+  --border-color: #64748b;
+  --advice-bg: #263244;
+  --surface-shadow: 0 8px 24px rgba(0,0,0,0.35);
+  color-scheme: dark;
+}
+
 html { font-size: var(--base-font-size); }
 body {
   font-family: 'Noto Sans JP', sans-serif;
   font-weight: 400;
   display: flex; flex-direction: column; align-items: center; justify-content: center;
   min-height: 100vh;
-  background-color: #f0f2f5;
-  color: #333;
+  background-color: var(--page-bg);
+  color: var(--text-color);
   margin: 0;
   padding: 1em;
   box-sizing: border-box;
-  transition: background-color 0.5s ease;
+  transition: background-color 0.25s ease, color 0.25s ease;
 }
 .container {
-  background-color: #fff;
+  background-color: var(--surface-bg);
   padding: var(--container-padding);
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  box-shadow: var(--surface-shadow);
   text-align: center;
   width: 100%;
   max-width: 600px;
   margin: max(1vh, 1em) 0;
   box-sizing: border-box;
-  transition: box-shadow 0.5s ease;
+  transition: background-color 0.25s ease, box-shadow 0.25s ease;
   position: relative;
 }
 
-/* Shake Animation for incorrect answer */
 @keyframes shake {
   0% { transform: translateX(0); }
   20% { transform: translateX(-10px); }
@@ -43,9 +74,7 @@ body {
   80% { transform: translateX(10px); }
   100% { transform: translateX(0); }
 }
-.shake {
-  animation: shake 0.4s ease-in-out;
-}
+.shake { animation: shake 0.4s ease-in-out; }
 
 .header-row {
   display: flex;
@@ -53,60 +82,74 @@ body {
   align-items: center;
   position: relative;
   margin-bottom: 0.7em;
+  min-height: 2.5rem;
 }
-
 h1 {
-  color: #1a73e8;
+  color: var(--primary-color);
   margin: 0;
   font-size: var(--title-font-size);
   font-weight: 700;
   text-shadow: 1px 1px 2px rgba(0,0,0,0.15);
 }
-
-#sound-toggle-btn {
+.header-icon-btn {
   position: absolute;
-  right: 0;
-  background: none;
-  border: none;
-  font-size: 1.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: 1px solid transparent;
+  font-size: 1.45rem;
   cursor: pointer;
-  padding: 0;
-  min-width: auto;
+  padding: 0.2rem;
+  min-width: 2.4rem;
+  min-height: 2.4rem;
   box-shadow: none;
-  transition: transform 0.2s;
+  color: var(--text-color);
+  border-radius: 50%;
 }
-#sound-toggle-btn:hover { transform: scale(1.2); box-shadow: none; }
-#sound-toggle-btn.muted { opacity: 0.5; filter: grayscale(100%); }
+.header-icon-btn:hover {
+  transform: translateY(-50%) scale(1.12);
+  background: var(--primary-soft-bg);
+  box-shadow: none;
+}
+.header-icon-btn:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 2px;
+}
+.theme-toggle-btn { left: 0; }
+.sound-toggle-btn { right: 0; }
+.sound-toggle-btn.muted { opacity: 0.5; filter: grayscale(100%); }
 
 #highlight-switcher {
   display: inline-flex; align-items: center; gap: 0.4em;
   margin-bottom: 0.4em; font-size: 0.98em; user-select: none;
+  flex-wrap: wrap; justify-content: center;
 }
+.highlight-description { font-size: 0.9em; color: var(--muted-text); }
 #highlight-btn {
-  padding: 0.2em 1.2em; border: 1.5px solid #666;
-  background: #eee; color: #222; border-radius: 6px;
+  padding: 0.2em 1.2em; border: 1.5px solid var(--border-color);
+  background: var(--neutral-button-bg); color: var(--neutral-button-text); border-radius: 6px;
   font-weight: 700; cursor: pointer; margin-left: 0.5em;
   transition: background 0.18s, color 0.18s;
   min-width: 60px;
 }
-#highlight-btn.active { background: #1a73e8; color: #fff; border-color: #1a73e8; }
+#highlight-btn.active { background: var(--primary-color); color: #fff; border-color: var(--primary-color); }
 
 #cb-mode-switcher {
   display: flex; justify-content: center; gap: 0.5em; margin-bottom: 1em; align-items: center; flex-wrap: wrap;
 }
 #cb-mode-switcher button {
-  background: #e8f0fe; color: #222; border: 1.5px solid #1a73e8;
+  background: var(--primary-soft-bg); color: var(--text-color); border: 1.5px solid var(--primary-color);
   border-radius: 6px; padding: 0.4em 1.1em; font-size: 1em;
   font-weight: 700; cursor: pointer; outline: none;
   transition: background 0.2s, color 0.2s; position: relative;
   min-width: auto;
 }
 #cb-mode-switcher button.selected, #cb-mode-switcher button:focus {
-  background: #1a73e8; color: #fff; z-index: 1;
+  background: var(--primary-color); color: #fff; z-index: 1;
 }
 #cb-tooltip {
   display: inline-block; margin-left: 1em; font-size: 0.95em;
-  color: #557; background: #f4f7fa; border-radius: 6px;
+  color: var(--muted-text); background: var(--secondary-bg); border-radius: 6px;
   padding: 0.5em 1em; box-shadow: 0 1px 5px rgba(20,60,140,0.08);
   min-width: 160px; max-width: 320px; text-align: left; line-height: 1.5; position: relative;
 }
@@ -114,7 +157,7 @@ h1 {
 
 #game-info {
   display: flex; justify-content: space-around; align-items: center;
-  margin-bottom: 1.2em; padding: 0.8em 1em; background-color: #e8f0fe;
+  margin-bottom: 1.2em; padding: 0.8em 1em; background-color: var(--primary-soft-bg);
   border-radius: 6px; font-size: var(--info-font-size);
   flex-wrap: wrap; gap: 10px 15px; font-weight: 700;
 }
@@ -127,7 +170,7 @@ h1 {
   display: grid; grid-template-columns: repeat(5, 1fr); gap: var(--panel-gap);
   width: 100%; max-width: min(450px, calc(95vw - var(--container-padding) * 2));
   aspect-ratio: 1 / 1; margin: 1.2em auto;
-  background-color: #eee; padding: var(--board-gap); border-radius: 6px; box-sizing: border-box;
+  background-color: var(--board-bg); padding: var(--board-gap); border-radius: 6px; box-sizing: border-box;
 }
 .panel {
   background-color: #ccc; border-radius: 4px; cursor: pointer;
@@ -135,12 +178,21 @@ h1 {
   width: 100%; height: 0; padding-bottom: 100%; box-sizing: border-box; position: relative; overflow: hidden;
 }
 .panel:hover { transform: scale(1.05); box-shadow: 0 2px 6px rgba(0,0,0,0.2); z-index: 1; }
-.panel:focus { outline: 2px solid #1a73e8; outline-offset: 2px; z-index: 1; }
+.panel:focus { outline: 2px solid var(--primary-color); outline-offset: 2px; z-index: 1; }
 .panel.wrong { animation: shake 0.4s ease-in-out; }
 
 #result-message {
   font-size: 1.2rem; font-weight: 700; min-height: 1.5em; margin-bottom: 1em; transition: color 0.3s ease;
 }
+.app-status {
+  margin: -0.4em 0 1em;
+  padding: 0.75em;
+  border-radius: 6px;
+  background: #fff4d6;
+  color: #714c00;
+  font-size: 0.9rem;
+}
+html[data-theme="dark"] .app-status { background: #4a3910; color: #ffe8a3; }
 
 .controls { display: flex; justify-content: center; gap: 15px; flex-wrap: wrap; }
 button {
@@ -161,12 +213,18 @@ button:disabled { opacity: 0.6; cursor: not-allowed; transform: none; box-shadow
 body.game-cleared { animation: celebrate-bg 1.5s infinite alternate; }
 .container.game-cleared { box-shadow: 0 0 25px rgba(255,215,0,0.7); }
 #result-message.cleared { animation: celebrate-text 1s infinite alternate; font-size: 1.4rem; }
-@keyframes celebrate-bg { from { background-color: #f0f2f5; } to { background-color: #fffacd; } }
+@keyframes celebrate-bg { from { background-color: var(--page-bg); } to { background-color: #fffacd; } }
+@keyframes celebrate-bg-dark { from { background-color: #111827; } to { background-color: #4a3f08; } }
 @keyframes celebrate-text { from { transform: scale(1); color: blue; } to { transform: scale(1.1); color: gold; } }
+html[data-theme="dark"] body.game-cleared { animation-name: celebrate-bg-dark; }
 
 #advice-message {
-  margin-top: 1.4em; color: #888; font-size: 0.98em;
-  background: #fcfcfc; border-radius: 6px; padding: 1em 0.8em 0.7em;
+  margin-top: 1.4em; color: var(--muted-text); font-size: 0.98em;
+  background: var(--advice-bg); border-radius: 6px; padding: 1em 0.8em 0.7em;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; }
 }
 
 @media (max-width: 600px) {
@@ -179,7 +237,10 @@ body.game-cleared { animation: celebrate-bg 1.5s infinite alternate; }
   button { padding: 0.7em 1.2em; min-width: 100px; }
   #result-message { font-size: 1.1rem; }
   #result-message.cleared { font-size: 1.3rem; }
-  #sound-toggle-btn { position: relative; display: block; margin-left: 10px; }
+  .header-icon-btn { position: relative; top: auto; transform: none; }
+  .header-icon-btn:hover { transform: scale(1.12); }
+  .theme-toggle-btn { left: auto; margin-right: 8px; }
+  .sound-toggle-btn { right: auto; margin-left: 8px; }
 }
 @media (max-width: 400px) {
   :root { --base-font-size: 13px; --container-padding: 1em; --title-font-size: 1.6rem; }

--- a/tests/static-check.cjs
+++ b/tests/static-check.cjs
@@ -1,0 +1,23 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.join(__dirname, '..');
+const html = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const css = fs.readFileSync(path.join(root, 'style.css'), 'utf8');
+const themeSafety = fs.readFileSync(path.join(root, 'theme-safety.js'), 'utf8');
+
+const gameScriptPosition = html.indexOf('src="script.js"');
+const safetyScriptPosition = html.indexOf('src="theme-safety.js"');
+
+assert.ok(html.includes('id="theme-toggle-btn"'), 'テーマ切替ボタンがありません');
+assert.ok(html.includes('id="app-status"'), 'エラー状態表示がありません');
+assert.ok(gameScriptPosition >= 0, 'script.jsが読み込まれていません');
+assert.ok(safetyScriptPosition > gameScriptPosition, 'theme-safety.jsはSoundManager定義後に読み込む必要があります');
+assert.ok(css.includes('html[data-theme="dark"]'), 'ダークテーマのCSSがありません');
+assert.ok(css.includes('prefers-reduced-motion'), '動きを減らす設定への対応がありません');
+assert.ok(themeSafety.includes("const THEME_STORAGE_KEY = 'colorGameTheme'"), 'テーマ保存キーが想定と異なります');
+assert.ok(themeSafety.includes("matchMedia('(prefers-color-scheme: dark)')"), 'システムテーマの参照がありません');
+assert.ok(themeSafety.includes("typeof SoundManager !== 'undefined'"), '音声機能の安全対策がありません');
+
+console.log('ダークモードと安全対策の静的確認が完了しました');

--- a/theme-safety.js
+++ b/theme-safety.js
@@ -50,12 +50,18 @@
     status.classList.remove('hidden');
   }
 
+  function handleSystemThemeChange(event) {
+    if (!manualTheme) applyTheme(event.matches ? 'dark' : 'light');
+  }
+
   manualTheme = readStoredTheme();
   applyTheme(manualTheme || getSystemTheme());
 
-  systemTheme.addEventListener('change', event => {
-    if (!manualTheme) applyTheme(event.matches ? 'dark' : 'light');
-  });
+  if (typeof systemTheme.addEventListener === 'function') {
+    systemTheme.addEventListener('change', handleSystemThemeChange);
+  } else if (typeof systemTheme.addListener === 'function') {
+    systemTheme.addListener(handleSystemThemeChange);
+  }
 
   document.addEventListener('DOMContentLoaded', () => {
     updateThemeButton(document.documentElement.dataset.theme);
@@ -100,7 +106,7 @@
     };
 
     SoundManager.prototype.toggle = function() {
-      if (!window.AudioContext && !window.webkitAudioContext) {
+      if (!this.audioCtx && !this.init()) {
         this.enabled = false;
         return false;
       }

--- a/theme-safety.js
+++ b/theme-safety.js
@@ -1,0 +1,131 @@
+(() => {
+  'use strict';
+
+  const THEME_STORAGE_KEY = 'colorGameTheme';
+  const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+  let manualTheme = null;
+
+  function readStoredTheme() {
+    try {
+      const value = localStorage.getItem(THEME_STORAGE_KEY);
+      return value === 'light' || value === 'dark' ? value : null;
+    } catch (error) {
+      console.warn('テーマ設定を読み込めませんでした。', error);
+      return null;
+    }
+  }
+
+  function saveTheme(theme) {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch (error) {
+      console.warn('テーマ設定を保存できませんでした。', error);
+    }
+  }
+
+  function getSystemTheme() {
+    return systemTheme.matches ? 'dark' : 'light';
+  }
+
+  function updateThemeButton(theme) {
+    const button = document.getElementById('theme-toggle-btn');
+    if (!button) return;
+
+    const isDark = theme === 'dark';
+    button.textContent = isDark ? '☀️' : '🌙';
+    button.setAttribute('aria-label', isDark ? 'ライトモードへ切り替える' : 'ダークモードへ切り替える');
+    button.setAttribute('aria-pressed', String(isDark));
+  }
+
+  function applyTheme(theme) {
+    const safeTheme = theme === 'dark' ? 'dark' : 'light';
+    document.documentElement.dataset.theme = safeTheme;
+    updateThemeButton(safeTheme);
+  }
+
+  function showSafetyMessage(message) {
+    const status = document.getElementById('app-status');
+    if (!status) return;
+    status.textContent = message;
+    status.classList.remove('hidden');
+  }
+
+  manualTheme = readStoredTheme();
+  applyTheme(manualTheme || getSystemTheme());
+
+  systemTheme.addEventListener('change', event => {
+    if (!manualTheme) applyTheme(event.matches ? 'dark' : 'light');
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    updateThemeButton(document.documentElement.dataset.theme);
+
+    const button = document.getElementById('theme-toggle-btn');
+    if (button) {
+      button.addEventListener('click', () => {
+        const nextTheme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+        manualTheme = nextTheme;
+        saveTheme(nextTheme);
+        applyTheme(nextTheme);
+      });
+    }
+  });
+
+  if (typeof SoundManager !== 'undefined') {
+    const originalPlayTone = SoundManager.prototype.playTone;
+
+    SoundManager.prototype.init = function() {
+      const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+      if (!AudioContextClass) {
+        this.audioCtx = null;
+        this.enabled = false;
+        return false;
+      }
+
+      try {
+        if (!this.audioCtx) this.audioCtx = new AudioContextClass();
+        if (this.audioCtx.state === 'suspended') {
+          const resumeResult = this.audioCtx.resume();
+          if (resumeResult && typeof resumeResult.catch === 'function') {
+            resumeResult.catch(error => console.warn('音声の再開に失敗しました。', error));
+          }
+        }
+        return true;
+      } catch (error) {
+        console.warn('音声機能を初期化できませんでした。', error);
+        this.audioCtx = null;
+        this.enabled = false;
+        return false;
+      }
+    };
+
+    SoundManager.prototype.toggle = function() {
+      if (!window.AudioContext && !window.webkitAudioContext) {
+        this.enabled = false;
+        return false;
+      }
+      this.enabled = !this.enabled;
+      return this.enabled;
+    };
+
+    SoundManager.prototype.playTone = function(...args) {
+      try {
+        return originalPlayTone.apply(this, args);
+      } catch (error) {
+        console.warn('効果音を再生できませんでした。', error);
+        this.audioCtx = null;
+        return undefined;
+      }
+    };
+  }
+
+  window.addEventListener('error', event => {
+    console.error('Color game runtime error:', event.error || event.message);
+    showSafetyMessage('一部の処理でエラーが発生しました。ページを再読み込みしてください。');
+  });
+
+  window.addEventListener('unhandledrejection', event => {
+    console.error('Color game unhandled rejection:', event.reason);
+    showSafetyMessage('一部の処理を完了できませんでした。通信環境を確認して再度お試しください。');
+  });
+})();


### PR DESCRIPTION
## 変更内容
- OSのライト／ダーク設定へ自動追従
- 画面左上のボタンから手動切替し、`colorGameTheme`へ選択を保存
- ページ背景、情報枠、補足、操作UIへ役割別のテーマカラーを適用
- 色判定に使う25枚のパネル色とゲームロジックは変更しない
- `prefers-reduced-motion`に対応
- Web Audio API非対応・初期化失敗時もゲーム本体を無音で継続
- 未処理エラーを画面へ簡潔に通知
- JavaScript構文とテーマ構成を確認するGitHub Actionsを追加

## 既存Draft PR #4を使わない理由
PR #4は2025年12月時点の古いmainを基に、HTML・CSS・JSを大きく置き換える内容です。現行mainではファイル分離、サウンド、タイマー競合、色生成修正が進んでいるため、その差分を維持したまま限定実装しました。

## 新しい状態
- localStorageキー: `colorGameTheme`
- 値: `light`または`dark`

## 変更していないもの
- 既存タイトル・ゲーム内文言
- 問題数、ライフ、スコア、タイマー
- 色覚変換行列、出題色、正解判定

Fixes #3